### PR TITLE
Add symbols.defaultFoldersAssociations setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,14 @@
 				"symbols.defaultAssociations": {
 					"type": "boolean",
 					"default": true,
-					"description": "Allows you to use the default icons for files and folders or disable them and specify your own via symbols.files.associations and symbols.folders.associations."
+					"title": "Default Files Associations",
+					"description": "Allows you to use the default icons for files or disable them and specify your own via symbols.files.associations."
+				},
+				"symbols.defaultFoldersAssociations": {
+					"type": "boolean",
+					"default": true,
+					"title": "Default Folders Associations",
+					"description": "Allows you to use the default icons for folders or disable them and specify your own via symbols.folders.associations."
 				},
 				"symbols.folders.associations": {
 					"type": "object",

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,6 +1,7 @@
 const vscode = require("vscode");
 const { monitorConfigChanges } = require("./lib/change-listener");
 const { syncOriginal } = require("./lib/theme");
+const { migratedefaultFoldersAssociations } = require("./lib/config");
 const { log } = require("./lib/log");
 /**
  * @param {vscode.ExtensionContext} context
@@ -8,6 +9,7 @@ const { log } = require("./lib/log");
 async function activate(context) {
 	log.info("miguelsolorio.symbols activated");
 	await syncOriginal();
+	await migratedefaultFoldersAssociations();
 	monitorConfigChanges();
 
 	vscode.workspace.onDidChangeConfiguration(monitorConfigChanges);

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -49,6 +49,34 @@ function themeJSONToConfig(themeDef) {
 }
 
 /**
+ * @description migrate defaultFoldersAssociations setting for existing users
+ */
+async function migratedefaultFoldersAssociations() {
+	const config = vscode.workspace.getConfiguration("symbols");
+	const defaultFoldersAssociationsInspect = config.inspect("defaultFoldersAssociations");
+	
+	if (defaultFoldersAssociationsInspect.workspaceValue === undefined && 
+	    defaultFoldersAssociationsInspect.globalValue === undefined) {
+		
+		const defaultAssociations = config.get("defaultAssociations", true);
+		
+		const defaultAssociationsInspect = config.inspect("defaultAssociations");
+		const hasCustomDefaultAssociations = 
+			defaultAssociationsInspect.workspaceValue !== undefined || 
+			defaultAssociationsInspect.globalValue !== undefined;
+		
+		if (hasCustomDefaultAssociations) {
+			log.info(`🔄 Migrating defaultAssociations value (${defaultAssociations}) to defaultFoldersAssociations`);
+			if (defaultAssociationsInspect.workspaceValue !== undefined) {
+				await config.update("defaultFoldersAssociations", defaultAssociations, vscode.ConfigurationTarget.Workspace);
+			} else {
+				await config.update("defaultFoldersAssociations", defaultAssociations, vscode.ConfigurationTarget.Global);
+			}
+		}
+	}
+}
+
+/**
  * @description update the changed property in the global settings and
  * in the theme definition file
  */
@@ -61,6 +89,11 @@ function updateConfig(config) {
 		themeJSON.fileExtensions = {};
 		themeJSON.fileNames = {};
 		themeJSON.languageIds = {};
+	}
+
+	const usedefaultFoldersAssociations = vscode.workspace.getConfiguration("symbols").get("defaultFoldersAssociations", true);
+	log.info(`🤖 symbols.defaultFoldersAssociations changed, updating to ${usedefaultFoldersAssociations}`);
+	if (usedefaultFoldersAssociations === false) {
 		themeJSON.folderNames = {};
 	}
 
@@ -79,4 +112,5 @@ module.exports = {
 	getWorkspaceConfiguration,
 	themeJSONToConfig,
 	updateConfig,
+	migratedefaultFoldersAssociations,
 };


### PR DESCRIPTION
## Description
<!-- What does this PR do? What file types/folders does it affect? -->
Add new setting `defaultFoldersAssociations` for enabling/disabling icons for folders.
Change setting `defaultAssociations`, now it affects only file icons, left name the same for backward compatibility.
To sync value of `defaultFoldersAssociations` with value of `defaultAssociations` (for users who set `defaultAssociations = false`) add `migratedefaultFoldersAssociations`.

## Type of Change
- [ ] New icon
- [ ] Update to existing icon
- [ ] Bug fix
- [x] Other (specify):
New setting: `defaultFoldersAssociations`


## Checklist
- [ ] Followed design guidelines (24x24px, 1px stroke, existing colors)
- [ ] SVG optimized and under 2KB
- [ ] Updated `src/symbol-icon-theme.json` with icon definition and associations
- [ ] Ran `npm run generate-previews` and committed preview files
- [ ] Ran `npm run check-format:fix`
- [x] Tested locally in VS Code (press F5)
- [ ] Included screenshot above

## Related Issues
<!-- Link related issues. -->
Fixes #339