### PR TITLE
Add defaultFoldersAssociations setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,14 @@
 				"symbols.defaultAssociations": {
 					"type": "boolean",
 					"default": true,
-					"description": "Allows you to use the default icons for files and folders or disable them and specify your own via symbols.files.associations and symbols.folders.associations."
+					"title": "Default Files Associations",
+					"description": "Allows you to use the default icons for files or disable them and specify your own via symbols.files.associations."
+				},
+				"symbols.defaultFoldersAssociations": {
+					"type": "boolean",
+					"default": true,
+					"title": "Default Folders Associations",
+					"description": "Allows you to use the default icons for folders or disable them and specify your own via symbols.folders.associations."
 				},
 				"symbols.folders.associations": {
 					"type": "object",

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,13 +1,15 @@
 const vscode = require("vscode");
 const { monitorConfigChanges } = require("./lib/change-listener");
 const { syncOriginal } = require("./lib/theme");
+const { migrateDefaultFoldersAssociations } = require("./lib/config");
 const { log } = require("./lib/log");
 /**
  * @param {vscode.ExtensionContext} context
  */
-async function activate(context) {
+async function activate(_context) {
 	log.info("miguelsolorio.symbols activated");
 	await syncOriginal();
+	await migrateDefaultFoldersAssociations();
 	monitorConfigChanges();
 
 	vscode.workspace.onDidChangeConfiguration(monitorConfigChanges);


### PR DESCRIPTION
## Description
Add new setting `defaultFoldersAssociations` for enabling/disabling icons for folders.
Change setting `defaultAssociations`, now it affects only file icons, left name the same for backward compatibility.
Add function `migratedefaultFoldersAssociations` to sync value of `defaultFoldersAssociations` with value of `defaultAssociations` (for users who set `defaultAssociations = false`).

## Type of Change
- [ ] New icon
- [ ] Update to existing icon
- [ ] Bug fix
- [x] Other (specify):
Add new setting `defaultFoldersAssociations`

## Checklist
- [ ] Followed design guidelines (24x24px, 1px stroke, existing colors)
- [ ] SVG optimized and under 2KB
- [ ] Updated `src/symbol-icon-theme.json` with icon definition and associations
- [ ] Ran `npm run generate-previews` and committed preview files
- [x] Ran `npm run check-format:fix`
- [x] Tested locally in VS Code (press F5)
- [ ] Included screenshot above

## Related Issues
<!-- Link related issues. -->
Fixes #339 