### PR TITLE
feat: add support for Svelte TypeScript config files

### DIFF
--- a/src/symbol-icon-theme.json
+++ b/src/symbol-icon-theme.json
@@ -1015,6 +1015,8 @@
 		"graphql.config.yml": "graphql",
 		"svelte.config.js": "svelte",
 		"svelte.config.cjs": "svelte",
+		"svelte.config.ts": "svelte-ts",
+		"svelte.config.cts": "svelte-ts",
 		"svelte.ts": "svelte-ts",
 		".Rhistory": "r",
 		".pug-lintrc": "pug",


### PR DESCRIPTION
## Description
Since [Svelte support .config.ts](https://github.com/sveltejs/kit/pull/13935) files, appropriate icons would be nice.


## Type of Change
- [ ] New icon
- [ ] Update to existing icon
- [ ] Bug fix
- [x] Other (specify):
Map file to its proper icon


## Checklist
- [ ] Followed design guidelines (24x24px, 1px stroke, existing colors)
- [ ] SVG optimized and under 2KB
- [x] Updated `src/symbol-icon-theme.json` with icon definition and associations
- [ ] Ran `npm run generate-previews` and committed preview files
- [ ] Ran `npm run check-format:fix`
- [ ] Tested locally in VS Code (press F5)
- [ ] Included screenshot above