### PR TITLE
feat: add husky support

### DIFF
--- a/src/symbol-icon-theme.json
+++ b/src/symbol-icon-theme.json
@@ -1759,6 +1759,7 @@
 	},
 
 	"folderNames": {
+		".husky": "folder-orange",
 		".changeset": "folder-changeset",
 		"i18n": "folder-i18n",
 		"locales": "folder-i18n",


### PR DESCRIPTION
## Description
Adds compatibility with Husky. But Husky doesn't have an icon, so what I did was add the folder icon with an orange dot.


## Type of Change
- [x] New icon
- [ ] Update to existing icon
- [ ] Bug fix
- [ ] Other (specify):

## Screenshots
<!-- Required for icon changes. Show your icon in VS Code's file tree -->

**Before:**
<img width="362" height="200" alt="image" src="https://github.com/user-attachments/assets/d463fff4-c8e6-431c-a757-15439f619d82" />


**After:**
<img width="358" height="148" alt="image" src="https://github.com/user-attachments/assets/dc0b42ec-95fc-4c59-a8c8-eff6a68953e3" />

## Checklist
- [x] Followed design guidelines (24x24px, 1px stroke, existing colors)
- [x] SVG optimized and under 2KB
- [x] Updated `src/symbol-icon-theme.json` with icon definition and associations
- [ ] Ran `npm run generate-previews` and committed preview files
  - No, because I did not add new icon
- [x] Ran `npm run check-format:fix`
- [x] Tested locally in VS Code (press F5)
- [x] Included screenshot above

## Related Issues
- #120